### PR TITLE
chore: ux enhancements

### DIFF
--- a/tools/apps/da-permissions/da-permissions.css
+++ b/tools/apps/da-permissions/da-permissions.css
@@ -164,6 +164,26 @@ sl-button.pw-quiet-danger::part(base):hover:not(:disabled) {
   transform: translateY(-50%) rotate(180deg);
 }
 
+.site-clear-btn {
+  position: absolute;
+  right: 0.4rem;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  padding: 2px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--s2-gray-500);
+  border-radius: var(--s2-radius-75);
+}
+
+.site-clear-btn:hover {
+  color: var(--s2-gray-800);
+  background: var(--s2-gray-100);
+}
+
 .site-dropdown {
   position: absolute;
   top: calc(100% + 4px);

--- a/tools/apps/da-permissions/da-permissions.js
+++ b/tools/apps/da-permissions/da-permissions.js
@@ -612,7 +612,11 @@ class DaPermissionsApp extends LitElement {
                 @keydown=${this.handleSiteInputKey}
                 @sl-blur=${this.handleSiteInputBlur}
               ></sl-input>
-              <span class="site-chevron ${this._siteDropdownOpen ? 'is-open' : ''}" aria-hidden="true">${icon('Smock_ChevronDown_18_N', 18, 18, '0 0 18 18')}</span>
+              ${this._site && !this._siteDropdownOpen ? html`
+                <button class="site-clear-btn" aria-label="Clear site" @click=${() => this.navigateToOrg()}>${icon('S2_Icon_Close_20_N')}</button>
+              ` : html`
+                <span class="site-chevron ${this._siteDropdownOpen ? 'is-open' : ''}" aria-hidden="true">${icon('Smock_ChevronDown_18_N', 18, 18, '0 0 18 18')}</span>
+              `}
               ${this._siteDropdownOpen ? html`
                 <div class="site-dropdown" role="listbox">
                   ${this.filteredSites.map((site, i) => html`
@@ -802,6 +806,17 @@ class DaPermissionsApp extends LitElement {
     `;
   }
 
+  renderContextBar() {
+    if (this._state !== 'admin' || !this._site) return nothing;
+    return html`
+      <div class="context-back-bar">
+        <button class="context-back-btn" @click=${() => this.navigateToOrg()}>← ${this._org}</button>
+        <span class="context-sep">›</span>
+        <span class="context-site-label">${this._site}</span>
+      </div>
+    `;
+  }
+
   // ---- Render: admin view ----
 
   renderAdmin() {
@@ -809,13 +824,6 @@ class DaPermissionsApp extends LitElement {
     return html`
       ${this._readOnly ? html`
         <div class="message warning">You have read-only access to this configuration.</div>
-      ` : nothing}
-      ${this._site ? html`
-        <div class="context-back-bar">
-          <button class="context-back-btn" @click=${() => this.navigateToOrg()}>← ${this._org}</button>
-          <span class="context-sep">›</span>
-          <span class="context-site-label">${this._site}</span>
-        </div>
       ` : nothing}
       <div class="slots-list">
         ${this.permissionSlots.map((slot) => this.renderSlot(slot, orgSectionTitles[slot.path] ?? null))}
@@ -882,6 +890,7 @@ class DaPermissionsApp extends LitElement {
   render() {
     return html`
       ${this.renderToolbar()}
+      ${this.renderContextBar()}
       ${this.renderInfoPanel()}
       ${this.renderMessage()}
       <div class="da-content">


### PR DESCRIPTION
- Moves the breadcrumbs above the dismissible info panel.
- Adds a clear button to the site dropdown.

Test URLs:
- Before: https://main--da-blog-tools--aemsites.aem.live
- After: https://da-perms--da-blog-tools--aemsites.aem.live
