### PR TITLE
feat: pass appBaseUrl in publish workflow worker requests

### DIFF
--- a/tools/apps/publish-requests-inbox/api.js
+++ b/tools/apps/publish-requests-inbox/api.js
@@ -5,6 +5,8 @@ const WORKER_URL = 'https://publish-requests.aem-poc-lab.workers.dev';
 const CI_WORKER_URL = 'https://publish-requests-ci.aem-poc-lab.workers.dev';
 const LOCAL_WORKER_URL = 'http://localhost:8787';
 
+const APP_BASE_URL = 'https://da.live/app/aemsites/da-blog-tools/tools/apps/publish-requests-inbox/publish-requests-inbox';
+
 const CORS_PROXY = 'https://da-etc.adobeaem.workers.dev/cors';
 
 const { getDaAdmin } = await import('https://da.live/nx/public/utils/constants.js');
@@ -786,6 +788,7 @@ export async function resendPublishRequest(org, site, path, requesterEmail, toke
     const previewUrl = `https://main--${site}--${org}.aem.page${pagePath}`;
 
     const opts = getOpts(token, 'POST', {
+      appBaseUrl: APP_BASE_URL,
       org,
       site,
       path,

--- a/tools/plugins/request-for-publish/utils.js
+++ b/tools/plugins/request-for-publish/utils.js
@@ -5,6 +5,8 @@ const WORKER_URL = 'https://publish-requests.aem-poc-lab.workers.dev';
 const CI_WORKER_URL = 'https://publish-requests-ci.aem-poc-lab.workers.dev';
 const LOCAL_WORKER_URL = 'http://localhost:8787';
 
+const APP_BASE_URL = 'https://da.live/app/aemsites/da-blog-tools/tools/apps/publish-requests-inbox/publish-requests-inbox';
+
 const { getDaAdmin } = await import('https://da.live/nx/public/utils/constants.js');
 const { daFetch } = await import('https://da.live/nx/utils/daFetch.js');
 const DA_ADMIN = getDaAdmin();
@@ -424,7 +426,7 @@ export async function previewContent(org, site, path) {
  */
 export async function submitPublishRequest(requestData, token) {
   try {
-    const opts = getOpts(token, 'POST', requestData);
+    const opts = getOpts(token, 'POST', { appBaseUrl: APP_BASE_URL, ...requestData });
     const response = await fetch(`${getWorkerUrl()}/api/request-publish`, opts);
 
     const result = await response.json();
@@ -473,7 +475,7 @@ export async function submitPublishRequest(requestData, token) {
  */
 export async function resendPublishRequest(requestData, token) {
   try {
-    const opts = getOpts(token, 'POST', requestData);
+    const opts = getOpts(token, 'POST', { appBaseUrl: APP_BASE_URL, ...requestData });
     const response = await fetch(`${getWorkerUrl()}/api/request-publish`, opts);
 
     const result = await response.json();


### PR DESCRIPTION
Adds APP_BASE_URL constant to utils.js and api.js and injects it into all three /api/request-publish call sites (submit, plugin resend, inbox resend) so the worker can build approval email links pointing back to the da-blog-tools hosted inbox.

The worker validates appBaseUrl before use (https: + da.live hostname) so existing callers without the field continue to work unchanged.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--da-blog-tools--aemsites.aem.live
- After: https://app-url-change--da-blog-tools--aemsites.aem.live
